### PR TITLE
Update READEME.md to use safter `tee -a`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Highlights:
 ## Usage
 
 1. Pick a hostname for your local development
-  - `echo "127.0.0.1   local.dev" | sudo tee /etc/hosts > /dev/null`
-  - `echo "127.0.0.1   foo.local.dev" | sudo tee /etc/hosts > /dev/null`
+  - `echo "127.0.0.1   local.dev" | sudo tee -a /etc/hosts > /dev/null`
+  - `echo "127.0.0.1   foo.local.dev" | sudo tee -a /etc/hosts > /dev/null`
 1. Create a certificate
   - `gloss setup`
 1. Import the certificate to your keychain (Mac specific instructions below)


### PR DESCRIPTION
Without the `-a` ( append ) the instructions in the README will have you replace the entire `/etc/hosts` file. Which will remove `localhost` and cause a bit of pain. 

This is to suggest the safer approach.